### PR TITLE
Add AUR install option to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ Usage:  `./install.sh`  **[OPTIONS...]** **[COLOR VARIANTS...]**
 | -n        | Specify theme name (**Default:** _Sevi_)                                      |
 | -h        | Show this help                                                                |
 
+### Arch (Via AUR)
+
+The icon theme can be installed from the [sevi-icon-theme-full](https://aur.archlinux.org/packages/sevi-icon-theme-full) package on the AUR.
+
+If you use Yay as your AUR-helper, you can use the following command:
+`yay -S sevi-icon-theme-full`
+
 ## Preview
 
 ![Icons Preview](https://user-images.githubusercontent.com/754514/181782228-da3fc1db-745e-4962-83ef-b185697b0c71.png)


### PR DESCRIPTION
I'm maintaining an AUR package for this icon theme, so it can be easily updated on Arch systems.

Perhaps its worth mentioning this package on the AUR so other can use it too.