### PR TITLE
feat: add icon for ch.tlaun.TL

### DIFF
--- a/src/apps/scalable/ch.tlaun.TL.svg
+++ b/src/apps/scalable/ch.tlaun.TL.svg
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="64" height="64" version="1.1" viewBox="0 0 64" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <filter id="background" x="-.026999999" y="-.026999999" width="1.054" height="1.054" color-interpolation-filters="sRGB">
+      <feGaussianBlur id="feGaussianBlur340" stdDeviation="0.61875"/>
+    </filter>
+    <linearGradient id="backgroundPattern" x1="-127" x2="-82" y1="60" y2="5" gradientTransform="matrix(0.26458, 0, 0, 0.26458, 34.792, -64.134933)" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#121212" offset="0"/>
+      <stop stop-color="#252525" offset="0.5"/>
+      <stop stop-color="#121212" offset="1"/>
+    </linearGradient>
+    <linearGradient id="green" x1="25.68" x2="26.448" y1="39.395" y2="17.376" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#244f19" offset="0"/>
+      <stop stop-color="#499436" offset="1"/>
+    </linearGradient>
+    <linearGradient id="brown" x1="15.707" x2="25.68" y1="32.561" y2="39.395" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#9d6c49" offset="0"/>
+      <stop stop-color="#734b31" offset="1"/>
+    </linearGradient>
+  </defs>
+  <rect x="4.5" y="4.5" width="55" height="55" ry="15" fill="#141414" filter="url(#background)" opacity=".3" stroke-linecap="round" stroke-width="2.7444"/>
+  <rect x="4.5" y="-59.5" width="55" height="55" ry="15" fill="url(#backgroundPattern)" stroke-linecap="round" stroke-width=".72611" style="" transform="matrix(1, 0, 0, -1, 0, 0)"/>
+  <g transform="matrix(1, 0, 0, 1, -0.000032, -1.332944)" style="">
+    <g transform="matrix(1.3035 0 0 1.317 -2.4743 -7.8841)" fill-rule="evenodd">
+      <path d="m14.173 23.2 12.275 21.257 12.273-21.257-12.273-7.09" fill="url(#green)"/>
+      <path d="m14.173 23.2v3.543l12.274 7.09 1e-3 -3.547z" fill="#499839"/>
+      <path d="m26.448 33.827 12.274-7.087v-3.543l-12.274 7.086z" fill="#2e8221"/>
+      <path d="m14.173 26.74v10.63l12.274 7.087v-10.63z" fill="url(#brown)"/>
+      <path d="m26.448 33.827 12.274-7.087v10.63l-12.274 7.087z" fill="#472d1b"/>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Added custom icon for https://flathub.org/en/apps/ch.tlaun.TL
<img width="200" height="242" alt="image" src="https://github.com/user-attachments/assets/657db3de-db90-40c8-963c-23e19cbaf2ef" />
